### PR TITLE
Adding Compressor Profile

### DIFF
--- a/Sources/MarkersExtractor/Export/ExportProfile/ExportProfileFormat.swift
+++ b/Sources/MarkersExtractor/Export/ExportProfile/ExportProfileFormat.swift
@@ -16,6 +16,7 @@ public enum ExportProfileFormat: String {
     case tsv
     case xlsx
     case youtube
+    case compressor
 }
 
 extension ExportProfileFormat: Equatable { }
@@ -51,6 +52,8 @@ extension ExportProfileFormat {
             return "Excel (XLSX)"
         case .youtube:
             return "YouTube Chapters"
+        case .compressor:
+            return "Compressor Chapters"
         }
     }
     
@@ -72,6 +75,8 @@ extension ExportProfileFormat {
             return ExcelProfile.self
         case .youtube:
             return YouTubeProfile.self
+        case .compressor:
+            return CompressorProfile.self
         }
     }
 }

--- a/Sources/MarkersExtractor/Export/ExportProfile/Profiles/Compressor/CompressorProfile Export.swift
+++ b/Sources/MarkersExtractor/Export/ExportProfile/Profiles/Compressor/CompressorProfile Export.swift
@@ -1,0 +1,112 @@
+//
+//  CompressorProfile Export.swift
+//  MarkersExtractor • https://github.com/TheAcharya/MarkersExtractor
+//  Licensed under MIT License
+//
+
+import AVFoundation
+import Foundation
+import Logging
+import OrderedCollections
+import OTCore
+import TimecodeKitCore
+
+extension CompressorProfile {
+    public func prepareMarkers(
+        markers: [Marker],
+        idMode: MarkerIDMode,
+        tcStringFormat: Timecode.StringFormat,
+        useChapterMarkerPosterOffset: Bool,
+        payload: Payload,
+        mediaInfo: ExportMarkerMediaInfo?
+    ) -> [PreparedMarker] {
+        var preparedMarkers = markers.map {
+            PreparedMarker(
+                marker: $0,
+                idMode: idMode,
+                mediaInfo: mediaInfo,
+                tcStringFormat: tcStringFormat,
+                timeFormat: .timecode(stringFormat: tcStringFormat),
+                offsetToTimelineStart: true,
+                useChapterMarkerPosterOffset: useChapterMarkerPosterOffset
+            )
+        }
+        
+        // There is a bug in Compressor whereby the last marker is inadvertently omitted during the import process.
+        // As a workaround, the last marker is duplicated and renamed as "Dummy Marker".
+        if let lastMarker = markers.last {
+            let nullMarker = PreparedMarker(
+                marker: Marker(
+                    type: lastMarker.type,
+                    name: "Dummy Marker",
+                    notes: lastMarker.notes,
+                    roles: lastMarker.roles,
+                    position: lastMarker.position,
+                    parentInfo: lastMarker.parentInfo,
+                    metadata: lastMarker.metadata,
+                    xmlPath: lastMarker.xmlPath
+                ),
+                idMode: idMode,
+                mediaInfo: mediaInfo,
+                tcStringFormat: tcStringFormat,
+                timeFormat: .timecode(stringFormat: tcStringFormat),
+                offsetToTimelineStart: true,
+                useChapterMarkerPosterOffset: useChapterMarkerPosterOffset
+            )
+            preparedMarkers.append(nullMarker)
+        }
+        
+        return preparedMarkers
+    }
+    
+    public func writeManifests(
+        _ preparedMarkers: [PreparedMarker],
+        payload: Payload,
+        noMedia: Bool
+    ) throws {
+        let rows = dictsToRows(preparedMarkers, includeHeader: false, noMedia: noMedia)
+        
+        let txt = rows
+            .map { $0.joined(separator: "\t") }
+            .joined(separator: "\n")
+        
+        guard let txtData = txt.data(using: .utf8)
+        else {
+            throw MarkersExtractorError.extraction(.fileWrite(
+                "Could not encode text file."
+            ))
+        }
+        
+        try txtData.write(to: payload.txtPath)
+    }
+    
+    public func resultFileContent(payload: Payload) throws -> ExportResult.ResultDictionary {
+        [
+            .txtManifestPath: .url(payload.txtPath)
+        ]
+    }
+    
+    public func tableManifestFields(
+        for marker: PreparedMarker,
+        noMedia: Bool
+    ) -> OrderedDictionary<ExportField, String> {
+        var dict: OrderedDictionary<ExportField, String> = [:]
+        
+        dict[.position] = marker.position
+        dict[.name] = marker.name
+        
+        return dict
+    }
+    
+    public func nestedManifestFields(
+        for marker: PreparedMarker,
+        noMedia: Bool
+    ) -> OrderedDictionary<ExportField, ExportFieldValue> {
+        var dict: OrderedDictionary<ExportField, ExportFieldValue> = [:]
+        
+        dict[.position] = .string(marker.position)
+        dict[.name] = .string(marker.name)
+        
+        return dict
+    }
+}

--- a/Sources/MarkersExtractor/Export/ExportProfile/Profiles/Compressor/CompressorProfile.swift
+++ b/Sources/MarkersExtractor/Export/ExportProfile/Profiles/Compressor/CompressorProfile.swift
@@ -1,0 +1,26 @@
+//
+//  CompressorProfile.swift
+//  MarkersExtractor • https://github.com/TheAcharya/MarkersExtractor
+//  Licensed under MIT License
+//
+
+import Foundation
+import Logging
+
+public final class CompressorProfile: ExportProfile {
+    // ExportProfile
+    public typealias Payload = TextExportPayload
+    public typealias Icon = EmptyExportIcon
+    public typealias PreparedMarker = StandardExportMarker
+    public static let profile: ExportProfileFormat = .compressor
+    public static let isMediaCapable: Bool = false
+    public var logger: Logger?
+    
+    // ProgressReporting (omitted protocol conformance as it would force NSObject inheritance)
+    public let progress: Progress
+    
+    public required init(logger: Logger? = nil) {
+        self.logger = logger
+        progress = Self.defaultProgress
+    }
+}

--- a/Sources/MarkersExtractor/MarkersExtractor Export.swift
+++ b/Sources/MarkersExtractor/MarkersExtractor Export.swift
@@ -117,6 +117,19 @@ extension MarkersExtractor {
                 ),
                 parentProgress: parentProgress
             )
+            
+        case .compressor:
+            return try await export(
+                for: CompressorProfile.self,
+                media: media,
+                markers: markers,
+                outputURL: outputURL,
+                payload: .init(
+                    timelineName: timelineName,
+                    outputURL: outputURL
+                ),
+                parentProgress: parentProgress
+            )
         }
     }
     


### PR DESCRIPTION
#118

@orchetect With the help of AI, I have tried to add Compressor Profile spinning-off from YouTube Profile.

There is a bug in Compressor whereby the last marker is inadvertently omitted during the import process. Hence, as a workaround, I taught of  duplicating the  last marker and rename it to "Dummy Marker".

This is the output - 

```txt
00:00:12:21	Marker 1
00:00:39:00	Marker 2
00:01:13:04	Marker 3
00:01:42:16	Marker 4
00:02:15:11	Marker 5
00:02:41:11	Marker 6
00:02:50:00	Marker 7
00:02:50:00	Dummy Marker
```

The duplicating logic was created by ChatGPT.  It seems to be working.  I am not sure if it is 100% correct. Could you please  review it? If everything is okay, you can merge it with our main branch. 

Thank you.